### PR TITLE
Add an issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,50 @@
+> We LOVE to help with any issues or bugs you have!
+>
+> **Questions**: If you have questions about how to use Realm, ask on 
+> [StackOverflow](http://stackoverflow.com/questions/ask?tags=realm).
+> We monitor the `realm` tag.
+>
+> **Feature Request**: Just fill in the first two sections below.
+>
+> **Bugs**: To help you as fast as possible with an issue please describe your issue
+> and the steps you have taken to reproduce it in as many details as possible.
+>
+> Thanks for helping us help you! :-)
+>
+> Please remove this line and all above before submitting.
+
+## Goals
+
+What do you want to achieve?
+
+## Expected Results
+
+What did you expected to happen?
+
+## Actual Results
+
+What did happened instead?  
+e.g. the stack trace of a crash
+
+## Steps to Reproduce
+
+What are steps we can follow to reproduce this issue?
+
+## Code Sample
+
+Provide a code sample or test case that highlights the issue.
+If relevant, include your model definitions.
+For larger code samples, links to external gists/repositories are preferred.
+Alternatively share confidentially via mail to help@realm.io.
+Full projects that we can compile and run ourselves are ideal!
+
+## Version of Realm and Tooling
+
+Realm Object Server Version: ?
+Flavor: Enterprise / Professional / Developer
+
+Server OS & Version: ? (e.g. CentOS 6)
+
+Client SDK Version: ?
+
+Client OS & Version: ?


### PR DESCRIPTION
This is based on our issue templates we use on our Client SDK repos. It frames the most common question and gives a list of relevant involved variables and versions which provide us helpful data points, so that we can avoid unnecessary back and forth to investigate the scope of problems in case of bugs.